### PR TITLE
Fix prompt manager NRE

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Outer Wilds - Throwable Items Mod
-![image](https://github.com/VioVayo/OWThrowableItems/assets/127029039/304324df-214a-453f-8123-34c314bdefa0)
+![image](https://github.com/VioVayo/OWThrowableItems/assets/127029039/e4497f7a-9036-49b1-9d39-a49052d16149)
 
 While holding an item, <b>double tap</b> the `Interact` button to drop / let go of it.  
 This works in 0g environments.  

--- a/YeetMod/YeetMod.cs
+++ b/YeetMod/YeetMod.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 
 namespace YeetMod
 {
-    public class YeetMod : ModBehaviour
+    public class YeetMod : ModBehaviour, ILateInitializer
     {
         private static ScreenPrompt yeetPrompt;
         // not const so theyre editable in UE
@@ -24,10 +24,20 @@ namespace YeetMod
 
             yeetPrompt = new(InputLibrary.interact, "<CMD> " + "<color=orange>(x2) (Hold) </color> " + "Throw Item");
 
-            LoadManager.OnCompleteSceneLoad += (scene, loadScene) =>
+            LoadManager.OnCompleteSceneLoad += OnCompleteSceneLoad;
+        }
+
+        private void OnCompleteSceneLoad(OWScene scene, OWScene loadScene)
+        {
+            if (loadScene is OWScene.SolarSystem or OWScene.EyeOfTheUniverse)
             {
-                if (loadScene is OWScene.SolarSystem or OWScene.EyeOfTheUniverse) FindObjectOfType<PromptManager>().AddScreenPrompt(yeetPrompt, PromptPosition.LowerLeft);
-            };
+                LateInitializerManager.RegisterLateInitializer(this);
+            }
+        }
+
+        public void LateInitialize()
+        {
+            Locator.GetPromptManager().AddScreenPrompt(yeetPrompt, PromptPosition.LowerLeft);
         }
 
         private void Update()

--- a/YeetMod/YeetMod.cs
+++ b/YeetMod/YeetMod.cs
@@ -24,8 +24,9 @@ namespace YeetMod
 
             yeetPrompt = new(InputLibrary.interact, "<CMD> " + "<color=orange>(x2) (Hold) </color> " + "Throw Item");
 
-            LoadManager.OnCompleteSceneLoad += (scene, loadScene) =>
+            LoadManager.OnCompleteSceneLoad += (_, loadScene) =>
             {
+                yeetPrompt._isVisible = false;
                 if (loadScene is OWScene.SolarSystem or OWScene.EyeOfTheUniverse) FindObjectOfType<PromptManager>().AddScreenPrompt(yeetPrompt, PromptPosition.LowerLeft);
             };
         }

--- a/YeetMod/YeetMod.cs
+++ b/YeetMod/YeetMod.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 
 namespace YeetMod
 {
-    public class YeetMod : ModBehaviour, ILateInitializer
+    public class YeetMod : ModBehaviour
     {
         private static ScreenPrompt yeetPrompt;
         // not const so theyre editable in UE
@@ -31,13 +31,8 @@ namespace YeetMod
         {
             if (loadScene is OWScene.SolarSystem or OWScene.EyeOfTheUniverse)
             {
-                LateInitializerManager.RegisterLateInitializer(this);
+                ModHelper.Events.Unity.FireOnNextUpdate(() => Locator.GetPromptManager().AddScreenPrompt(yeetPrompt, PromptPosition.LowerLeft));
             }
-        }
-
-        public void LateInitialize()
-        {
-            Locator.GetPromptManager().AddScreenPrompt(yeetPrompt, PromptPosition.LowerLeft);
         }
 
         private void Update()


### PR DESCRIPTION
So that it doesn't kill every other mod (prompt manager would not have been registered to locator yet)

yes that happened to me
![image](https://github.com/VioVayo/OWThrowableItems/assets/34462599/e02a7bee-e41c-4ec7-99c4-992af73869b5)
```
NullReferenceException: Object reference not set to an instance of an object
Stacktrace: ScreenPrompt.SetVisibility (System.Boolean isVisible)
PromptManager.AddScreenPrompt (ScreenPrompt buttonPrompt, PromptPosition promptPosition, System.Boolean makeVisible)
YeetMod.YeetMod+<>c.<Start>b__7_0 (OWScene scene, OWScene loadScene) (at D:/Github/OWThrowableItems/YeetMod/YeetMod.cs:29)
LoadManager.OnSceneLoaded (UnityEngine.SceneManagement.Scene arg0, UnityEngine.SceneManagement.LoadSceneMode arg1)
UnityEngine.SceneManagement.SceneManager.Internal_SceneLoaded (UnityEngine.SceneManagement.Scene scene, UnityEngine.SceneManagement.LoadSceneMode mode)
```