### PR TITLE
Prevent items from disabling

### DIFF
--- a/YeetMod/ItemYeetSocket.cs
+++ b/YeetMod/ItemYeetSocket.cs
@@ -8,6 +8,7 @@ namespace YeetMod
 
         private OWRigidbody owRigidbody;
         private GameObject detectorObj = new("YeetDetector");
+        private GameObject soundObj = new("YeetImpactAudio");
         private SectorDetector sectorDetector;
         private OWItem attachedItem;
         private bool switchedFromInteractible;
@@ -46,15 +47,16 @@ namespace YeetMod
             sectorDetector.SetOccupantType(DynamicOccupant.Environment);
             Locator.GetPlayerSectorDetector().AddDetectorToAllOccupiedSectors(sectorDetector);
 
-            attachedItem.transform.parent = null;
-            gameObject.SetActive(false);
             gameObject.AddComponent<ImpactSensor>();
-            var objectImpactAudio = gameObject.AddComponent<ObjectImpactAudio>();
+
+            soundObj.transform.parent = attachedItem.transform;
+            soundObj.transform.localPosition = Vector3.zero;
+            soundObj.SetActive(false);
+            var objectImpactAudio = soundObj.AddComponent<ObjectImpactAudio>();
             objectImpactAudio._minPitch = 0.4f;
             objectImpactAudio._maxPitch = 0.6f;
             objectImpactAudio.Reset();
-            gameObject.SetActive(true);
-            attachedItem.transform.parent = transform;
+            soundObj.SetActive(true);
 
             attachedItem.onPickedUp += OnPickUpItem;
 
@@ -254,6 +256,7 @@ namespace YeetMod
             if (switchedFromInteractible) attachedItem.gameObject.layer = LayerMask.NameToLayer("Interactible");
             Destroy(gameObject);
             Destroy(detectorObj);
+            Destroy(soundObj);
         }
     }
 }

--- a/YeetMod/ItemYeetSocket.cs
+++ b/YeetMod/ItemYeetSocket.cs
@@ -46,7 +46,7 @@ namespace YeetMod
             sectorDetector.SetOccupantType(DynamicOccupant.Environment);
             Locator.GetPlayerSectorDetector().AddDetectorToAllOccupiedSectors(sectorDetector);
 
-            attachedItem.transform.SetParent(null, true);
+            attachedItem.transform.parent = null;
             gameObject.SetActive(false);
             gameObject.AddComponent<ImpactSensor>();
             var objectImpactAudio = gameObject.AddComponent<ObjectImpactAudio>();
@@ -54,7 +54,7 @@ namespace YeetMod
             objectImpactAudio._maxPitch = 0.6f;
             objectImpactAudio.Reset();
             gameObject.SetActive(true);
-            attachedItem.transform.SetParent(transform, false);
+            attachedItem.transform.parent = transform;
 
             attachedItem.onPickedUp += OnPickUpItem;
 

--- a/YeetMod/ItemYeetSocket.cs
+++ b/YeetMod/ItemYeetSocket.cs
@@ -46,6 +46,7 @@ namespace YeetMod
             sectorDetector.SetOccupantType(DynamicOccupant.Environment);
             Locator.GetPlayerSectorDetector().AddDetectorToAllOccupiedSectors(sectorDetector);
 
+            attachedItem.transform.SetParent(null, true);
             gameObject.SetActive(false);
             gameObject.AddComponent<ImpactSensor>();
             var objectImpactAudio = gameObject.AddComponent<ObjectImpactAudio>();
@@ -53,6 +54,7 @@ namespace YeetMod
             objectImpactAudio._maxPitch = 0.6f;
             objectImpactAudio.Reset();
             gameObject.SetActive(true);
+            attachedItem.transform.SetParent(transform, false);
 
             attachedItem.onPickedUp += OnPickUpItem;
 


### PR DESCRIPTION
I ran into some issues with custom items being disabled and enabled again when thrown, this just unparents the item before disabling the socket body and re-parents it afterwards.